### PR TITLE
git-deps: don't crash when -e isn't specified

### DIFF
--- a/bin/git-deps
+++ b/bin/git-deps
@@ -343,9 +343,10 @@ class DependencyDetector(object):
         return commit.message.split('\n', 1)[0]
 
     def is_excluded(self, commit):
-        for exclude in self.options.exclude_commits:
-            if self.branch_contains(commit, exclude):
-                return True
+        if self.options.exclude_commits is not None:
+            for exclude in self.options.exclude_commits:
+                if self.branch_contains(commit, exclude):
+                    return True
         return False
 
     def branch_contains(self, commit, branch):


### PR DESCRIPTION
$ ../git-config/bin/git-deps b19dc0eeb0a4495e5b6e8fce7f63b4ae6bc39fe5
Traceback (most recent call last):
  File "../git-config/bin/git-deps", line 447, in <module>
    main()
  File "../git-config/bin/git-deps", line 442, in main
    detector.find_dependencies(dependent_rev)
  File "../git-config/bin/git-deps", line 223, in find_dependencies
    self.find_dependencies_with_parent(dependent, parent)
  File "../git-config/bin/git-deps", line 243, in find_dependencies_with_parent
    self.blame_hunk(dependent, parent, path, hunk)
  File "../git-config/bin/git-deps", line 290, in blame_hunk
    if self.is_excluded(dependency):
  File "../git-config/bin/git-deps", line 346, in is_excluded
    for exclude in self.options.exclude_commits:
TypeError: 'NoneType' object is not iterable
