### PR TITLE
git-cherry-menu enhancements

### DIFF
--- a/bin/git-blacklist
+++ b/bin/git-blacklist
@@ -1,0 +1,103 @@
+#!/bin/bash
+#
+# Usage: git-blacklist add <upstream> <downstream> <match>
+#        git-blacklist remove <upstream> <downstream> <match> <skip-branch>
+# Blacklist a commits based on the first commit line search.
+
+option=$1
+upstream=$2
+downstream=$3
+search=$4
+branch=$5
+
+usage()
+{
+    me=`basename $0`
+
+    cat <<EOF >&2
+usage: ${me} <option> <upstream> <downstream> <keyword> [<skip-branch>]
+
+       ${me} add <upstream> <downstream> <keyword>
+       ${me} remove <upstream> <downstream> <keyword> [<skip-branch>]
+
+<option> one of:
+    add        blacklist all commits that have 'keyword' in their first commit line
+    remove     remove the blacklist note from all commits that have 'keyword' in their first commit line
+
+<upstream>:    upstream branch to backport to
+<downstream>:  downstream branch to backport from
+<keyword>:     keyword to match on in the first commit line
+<skip-branch>: skip-branch that should match additionally before removal of blacklist git note.
+               NOTE: the script assumes that the match is absolute and will thus fail to remove
+                     a blacklist note that has more information in the git note.
+EOF
+    exit 1
+}
+
+parse_opts()
+{
+    case "${option}" in
+    add)
+        if test $# != 4; then
+           usage
+        fi
+    ;;
+    remove)
+        if test $# != 5; then
+            usage
+        fi
+    ;;
+    *)
+        usage
+    ;;
+    esac
+}
+
+blacklist_add()
+{
+    count=0
+    BLACKLIST=`git-icing -v3 ${upstream} ${downstream} | grep ${search} | grep ^+ | awk -e '{ print $2 }'`
+
+    for sha in ${BLACKLIST}; do
+        git notes --ref=upstreaming append -m "skip: $upstream" $sha
+        if ! test $? -eq 0; then
+           echo "Fatal: $* failed! Aborting."
+           exit 1
+        fi
+        count=$(($count+1))
+    done
+    echo Blacklisted $count commits for branch $upstream
+}
+
+blacklist_remove()
+{
+    branch=$1
+    count=0
+    BLACKLIST=`git-icing -v3 ${upstream} ${downstream} | grep ${search} | grep ^. | awk -e '{ print $2 }'`
+
+    for sha in ${BLACKLIST}; do
+        msg=`git notes --ref=upstreaming show $sha`
+        if test "${msg}" = "skip: $branch"; then
+            git notes --ref=upstreaming remove $sha
+            if ! test $? -eq 0; then
+               echo "Fatal: $* failed! Aborting."
+               exit 1
+            fi
+            count=$(($count+1))
+        fi
+    done
+    echo Removed blacklist for $count commit for brach $branch
+}
+
+OPTS=$option
+main()
+{
+    parse_opts "$@"
+    case "${OPTS}" in
+    add) blacklist_add ;;
+    remove) blacklist_remove $branch ;;
+    esac
+}
+
+main "$@"
+exit 0

--- a/bin/git-blacklist
+++ b/bin/git-blacklist
@@ -26,7 +26,8 @@ usage: ${me} <option> <upstream> <downstream> <keyword> [<skip-branch>]
 
 <upstream>:    upstream branch to backport to
 <downstream>:  downstream branch to backport from
-<keyword>:     keyword to match on in the first commit line
+<keyword>:     keyword to match on in the first commit line. The keyword might also be a regular expression
+               that works with grep AND contains no spaces.
 <skip-branch>: skip-branch that should match additionally before removal of blacklist git note.
                NOTE: the script assumes that the match is absolute and will thus fail to remove
                      a blacklist note that has more information in the git note.
@@ -66,7 +67,7 @@ blacklist_add()
         fi
         count=$(($count+1))
     done
-    echo Blacklisted $count commits for branch $upstream
+    echo Blacklisted $count commits for upstream branch $upstream
 }
 
 blacklist_remove()
@@ -86,7 +87,7 @@ blacklist_remove()
             count=$(($count+1))
         fi
     done
-    echo Removed blacklist for $count commit for brach $branch
+    echo Removed blacklist for $count commit for upstream brach $branch
 }
 
 OPTS=$option

--- a/bin/git-cherry-menu
+++ b/bin/git-cherry-menu
@@ -45,6 +45,10 @@ suggested options:
           upstream branches. If one wants to blacklist a commit for a specific
           branch by default when doing a run of cherry-menu, then specify it here.
 
+    -c cherry-menu.skip-notes-edit=true
+          Skip editing the git-notes for this object. The default behaviour is to
+          edit the git note for this object when blacklisting.
+
 COMMAND is typically "git icing -v2" or "git cherry" but can be
 anything which gives output in the same format, e.g.
 
@@ -266,10 +270,12 @@ cherry_menu () {
 ###  (you can optionally change the "all" above to the name of the
 ###  upstream branch if you want to limit blacklisting to that upstream)
 
-### Enter your justification for blacklisting here or
+###  Enter your justification for blacklisting here or
 ###  remove the whole note to cancel blacklisting." "$sha1"
                 fi
-                safe_run git notes edit "$sha1" <&3
+                if ! $(git config cherry-menu.skip-notes-edit); then
+                    safe_run git notes edit "$sha1" <&3
+                fi
                 echo
                 if has_note "$sha1"; then
                     colour "1;35" "Blacklisted $abbrev_sha1"

--- a/bin/git-cherry-menu
+++ b/bin/git-cherry-menu
@@ -263,11 +263,11 @@ cherry_menu () {
                        branch="all"
                     fi
                     safe_run git notes append -m "skip: `echo $branch`
-XXX  (you can optionally change the "all" above to the name of the
-XXX  upstream branch if you want to limit blacklisting to that upstream)
+###  (you can optionally change the "all" above to the name of the
+###  upstream branch if you want to limit blacklisting to that upstream)
 
-XXX  Enter your justification for blacklisting here or
-XXX  remove the whole note to cancel blacklisting." "$sha1"
+### Enter your justification for blacklisting here or
+###  remove the whole note to cancel blacklisting." "$sha1"
                 fi
                 safe_run git notes edit "$sha1" <&3
                 echo

--- a/bin/git-cherry-menu
+++ b/bin/git-cherry-menu
@@ -40,6 +40,11 @@ suggested options:
           issue tracker without getting in the way during repeated
           runs of cherry-menu.
 
+    -c cherry-menu.skip-branch=<branch>
+          The blacklist default setting is to blacklist a commit for 'all'
+          upstream branches. If one wants to blacklist a commit for a specific
+          branch by default when doing a run of cherry-menu, then specify it here.
+
 COMMAND is typically "git icing -v2" or "git cherry" but can be
 anything which gives output in the same format, e.g.
 
@@ -253,12 +258,16 @@ cherry_menu () {
                 ;;
             b)
                 if ! has_note "$sha1"; then
-                    safe_run git notes append -m'skip: all
+                    branch="$(git config cherry-menu.skip-branch)"
+                    if test -z $branch; then
+                       branch="all"
+                    fi
+                    safe_run git notes append -m "skip: `echo $branch`
 XXX  (you can optionally change the "all" above to the name of the
 XXX  upstream branch if you want to limit blacklisting to that upstream)
 
 XXX  Enter your justification for blacklisting here or
-XXX  remove the whole note to cancel blacklisting.' "$sha1"
+XXX  remove the whole note to cancel blacklisting." "$sha1"
                 fi
                 safe_run git notes edit "$sha1" <&3
                 echo


### PR DESCRIPTION
Blacklisting a commit for a specific branch by hand on each git notes edit <object> is cumbersome when working on a large patch set. The addition of an option to add a specific branch instead of 'all' improves the git-cherry-menu work flow.
Therefor git-cherry-menu gained an option to override the default blacklist branch 'skip: all'  by specifying the option '-c cherry-menu.skip-branch=<specific branch>'.
